### PR TITLE
Release v1.0.7

### DIFF
--- a/lib/rules/defer.js
+++ b/lib/rules/defer.js
@@ -11,16 +11,39 @@ module.exports = exports = function(payload, fn) {
   // parse our payload url
   var uri = url.parse(data.url);
 
-  // get the page content
-  payload.getPageContent(function(err, content) {
+  // get the content
+  payload.getResponse(function(err, response) {
 
-    // did we get a error ?
+    // check for errors
     if(err) {
 
-      // debug
-      payload.error('Got a error trying to get the Page Content', err);
+      // output the error
+      payload.error('inline', 'Something went wrong while retrieving the page content', err);
 
       // done
+      return fn(err);
+
+    }
+
+    // the content to use
+    var content = null;
+
+    // get the content
+    if(response && 
+        response.content) {
+
+      // set the content
+      content = response.content.text || response.content.body || '';
+
+    }
+
+    // sanity check for content
+    if(S(content || '').isEmpty() === true) {
+
+      // debugging
+      payload.debug('inline', 'Skipping as content was empty');
+
+      // finish the callback
       return fn(null);
 
     }

--- a/lib/rules/inline.js
+++ b/lib/rules/inline.js
@@ -13,21 +13,41 @@ module.exports = exports = function(payload, fn) {
   var data      = payload.getData();
 
   // get the content
-  payload.getPageContent(function(err, content) {
+  payload.getResponse(function(err, response) {
 
     // check for errors
     if(err) {
 
       // output the error
-      payload.error('Something went wrong while retrieving the page content', err);
+      payload.error('inline', 'Something went wrong while retrieving the page content', err);
 
       // done
       return fn(err);
 
     }
 
+    // the content to use
+    var content = null;
+
+    // get the content
+    if(response && 
+        response.content) {
+
+      // set the content
+      content = response.content.text || response.content.body || '';
+
+    }
+
     // sanity check for content
-    if(S(content || '').isEmpty() === true) return fn(null);
+    if(S(content || '').isEmpty() === true) {
+
+      // debugging
+      payload.debug('inline', 'Skipping as content was empty');
+
+      // finish the callback
+      return fn(null);
+
+    }
 
     // get the lines of the code block
     var lines = content.split('\n');
@@ -77,8 +97,8 @@ module.exports = exports = function(payload, fn) {
 
         }, {
 
-          message:      'Inline ' + tag + ' was bigger than 2kb, moving to a external file could save $ on caching',
-          identifiers:  [ Math.round(len/1024) + 'kb' ],
+          message:      'Inline ' + tag + ' was bigger than $kb, moving to a external file could save $ on caching',
+          identifiers:  [ 10, Math.round(len/1024) + 'kb' ],
           code:         {
 
             start:    current,

--- a/lib/rules/typeattribute.js
+++ b/lib/rules/typeattribute.js
@@ -13,16 +13,39 @@ module.exports = exports = function(payload, fn) {
   // local var
   var last_current_line = -1;
 
-  // get the page content
-  payload.getPageContent(function(err, content) {
+  // get the content
+  payload.getResponse(function(err, response) {
 
-    // did we get a error ?
+    // check for errors
     if(err) {
 
-      // debug
-      payload.error('Got a error trying to get the page content', err);
+      // output the error
+      payload.error('inline', 'Something went wrong while retrieving the page content', err);
 
       // done
+      return fn(err);
+
+    }
+
+    // the content to use
+    var content = null;
+
+    // get the content
+    if(response && 
+        response.content) {
+
+      // set the content
+      content = response.content.text || response.content.body || '';
+
+    }
+
+    // sanity check for content
+    if(S(content || '').isEmpty() === true) {
+
+      // debugging
+      payload.debug('inline', 'Skipping as content was empty');
+
+      // finish the callback
       return fn(null);
 
     }

--- a/test/defer.js
+++ b/test/defer.js
@@ -15,7 +15,44 @@ describe('defer', function() {
 
         url: 'http://example.com'
 
-      }, {}, null);
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: null
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, null);
 
     // execute the items
     testFunc(payload, function(err) {
@@ -37,7 +74,44 @@ describe('defer', function() {
 
         url: 'http://example.com'
 
-      }, {}, '');
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: ''
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, '');
 
     // execute the items
     testFunc(payload, function(err) {
@@ -63,7 +137,44 @@ describe('defer', function() {
 
         url: 'http://example.com'
         
-      }, null, content.toString())
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: content.toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, content.toString())
 
       // run the rules
       testFunc(payload, function(err) {
@@ -96,7 +207,44 @@ describe('defer', function() {
 
         url: 'http://example.com'
         
-      }, null, content.toString())
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: content.toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, content.toString())
 
       // run the rules
       testFunc(payload, function(err) {
@@ -129,7 +277,44 @@ describe('defer', function() {
 
         url: 'http://example.com'
         
-      }, null, content.toString())
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: content.toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, content.toString())
 
       // run the rules
       testFunc(payload, function(err) {

--- a/test/inline.js
+++ b/test/inline.js
@@ -16,7 +16,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, null);
+      }, 
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: null
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, null);
 
     // execute the items
     testFunc(payload, function(err) {
@@ -38,7 +75,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, '');
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: ''
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, '');
 
     // execute the items
     testFunc(payload, function(err) {
@@ -64,7 +138,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.head.html')).toString());
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.styles.head.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.head.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {
@@ -95,7 +206,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.body.html')).toString());
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.styles.body.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.body.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {
@@ -126,7 +274,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.ok.html')).toString());
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.styles.ok.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.ok.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {
@@ -157,7 +342,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.missing.html')).toString());
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.styles.missing.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.styles.missing.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {
@@ -193,7 +415,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.head.html')).toString());
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.head.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.head.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {
@@ -224,7 +483,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.body.html')).toString());
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.body.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.body.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {
@@ -255,7 +551,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.ok.html')).toString());
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.ok.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.ok.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {
@@ -286,7 +619,44 @@ describe('inline', function() {
 
         url: 'http://example.com'
 
-      }, {}, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.missing.html')).toString());
+      }, 
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.missing.html')).toString()
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, fs.readFileSync(path.join(__dirname, '../samples/inline.scripts.missing.html')).toString());
 
     // execute the items
     testFunc(payload, function(err) {

--- a/test/typeattribute.js
+++ b/test/typeattribute.js
@@ -15,7 +15,44 @@ describe('typeattribute', function() {
 
         url: 'http://example.com'
 
-      }, {}, null);
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: null
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, null);
 
     // execute the items
     testFunc(payload, function(err) {
@@ -37,7 +74,44 @@ describe('typeattribute', function() {
 
         url: 'http://example.com'
 
-      }, {}, '');
+      },
+      {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: ''
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, '');
 
     // execute the items
     testFunc(payload, function(err) {
@@ -56,14 +130,51 @@ describe('typeattribute', function() {
   it('Should have the type attribute rule present, even if uppercased', function(done) {
 
     // read in the html sample
-    var content = fs.readFileSync('./samples/typeattribute.bad.html');
+    var content = fs.readFileSync('./samples/typeattribute.bad.html').toString();
 
     // handle the payload
     payload = passmarked.createPayload({
 
       url: 'http://example.com'
       
-    }, null, content.toString())
+    },
+    {
+
+        log: {
+
+          entries: [
+
+            {
+
+              request:  {},
+              response: {
+
+                status: 200,
+                headers: [
+
+                  {
+
+                    name: 'content-type',
+                    value:  'text/html'
+
+                  }
+
+                ],
+                content: {
+
+                  text: content
+
+                }
+
+              }
+
+            }
+
+          ]
+
+        }
+
+      }, content)
 
     // run the rules
     testFunc(payload, function(err) {
@@ -92,14 +203,51 @@ describe('typeattribute', function() {
   it('Should have the type attribute rule present', function(done) {
 
     // read in the html sample
-    var content = fs.readFileSync('./samples/typeattribute.bad.html');
+    var content = fs.readFileSync('./samples/typeattribute.bad.html').toString();
 
     // handle the payload
     payload = passmarked.createPayload({
 
       url: 'http://example.com'
       
-    }, null, content.toString())
+    },
+    {
+
+      log: {
+
+        entries: [
+
+          {
+
+            request:  {},
+            response: {
+
+              status: 200,
+              headers: [
+
+                {
+
+                  name: 'content-type',
+                  value:  'text/html'
+
+                }
+
+              ],
+              content: {
+
+                text: content
+
+              }
+
+            }
+
+          }
+
+        ]
+
+      }
+
+    }, content.toString())
 
     // run the rules
     testFunc(payload, function(err) {
@@ -128,14 +276,51 @@ describe('typeattribute', function() {
   it('Should not have the type attribute rule present', function(done) {
 
     // read in the html sample
-    var content = fs.readFileSync('./samples/typeattribute.ok.html');
+    var content = fs.readFileSync('./samples/typeattribute.ok.html').toString();
 
     // handle the payload
     payload = passmarked.createPayload({
 
       url: 'http://example.com'
         
-    }, null, content.toString())
+    },
+    {
+
+      log: {
+
+        entries: [
+
+          {
+
+            request:  {},
+            response: {
+
+              status: 200,
+              headers: [
+
+                {
+
+                  name: 'content-type',
+                  value:  'text/html'
+
+                }
+
+              ],
+              content: {
+
+                text: content
+
+              }
+
+            }
+
+          }
+
+        ]
+
+      }
+
+    }, content.toString())
 
     // run the rules
     testFunc(payload, function(err) {
@@ -164,14 +349,51 @@ describe('typeattribute', function() {
   it('Should give a error on a page with no such tags', function(done) {
 
     // read in the html sample
-    var content = fs.readFileSync('./samples/typeattribute.missing.html');
+    var content = fs.readFileSync('./samples/typeattribute.missing.html').toString();
 
     // handle the payload
     payload = passmarked.createPayload({
 
       url: 'http://example.com'
         
-    }, null, content.toString())
+    },
+    {
+
+      log: {
+
+        entries: [
+
+          {
+
+            request:  {},
+            response: {
+
+              status: 200,
+              headers: [
+
+                {
+
+                  name: 'content-type',
+                  value:  'text/html'
+
+                }
+
+              ],
+              content: {
+
+                text: content
+
+              }
+
+            }
+
+          }
+
+        ]
+
+      }
+
+    }, content.toString())
 
     // run the rules
     testFunc(payload, function(err) {


### PR DESCRIPTION
Bigger release after our cleanup to make sure the rules are relevant to things to the user themselves can fix:

* Updated Defer to use the raw HAR response instead
* Updated "Type Attribute" to use the raw HAR response instead
* Updated inline to only worry about local instances, as widgets like Facebook/Olark were adding large blocks of CSS/Javascript that we were reporting. This is fine for us, as these blocks are added after the actual was loaded over the wire from the users server.